### PR TITLE
Add dockerfile to build standalone image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM asensei/vapor:latest
+
+EXPOSE 8080
+
+WORKDIR /app
+
+ADD . /app
+
+RUN vapor build
+
+CMD ["vapor", "run"]
+
+


### PR DESCRIPTION
To integrate in the JUG Server the project can be build by :
 - Building by a buildpack
 - Build a docker image with a Dockerfile

As swift on server side seems to be a expermiental use case I assume there is no build pack.
I just add a Dockerfile to build a standalone image of the project based on the README instructions.